### PR TITLE
fix #2

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,6 +112,8 @@ func output(label string, m *Module) {
 	if !(*flagDirect && m.Indirect) && !(*flagIndirect && !m.Indirect) {
 		m.Version = pseudoVersion.ReplaceAllString(m.Version, "$1")
 
+		m.Version = strings.TrimSuffix(m.Version, "+incompatible")
+
 		if strings.HasPrefix(m.Path, "golang.org/x/") {
 			m.httpPath = "github.com/golang/" + strings.TrimPrefix(m.Path, "golang.org/x/")
 		} else {


### PR DESCRIPTION
Just trim `+incompatible` suffix for versions. Referencing #2
```
Updated github.com/bxcodec/faker        https://github.com/bxcodec/faker/compare/v2.0.1...v3.5.0
Updated github.com/cenkalti/backoff     https://github.com/cenkalti/backoff/compare/v2.2.1...v4.1.0
Updated github.com/cespare/xxhash       https://github.com/cespare/xxhash/compare/v1.1.0...v2.1.1
Updated github.com/cpuguy83/go-md2man   https://github.com/cpuguy83/go-md2man/compare/v1.0.10...v2.0.1
Updated github.com/gavv/httpexpect      https://github.com/gavv/httpexpect/compare/v2.0.0...v2.1.0
Updated github.com/go-ozzo/ozzo-validation      https://github.com/go-ozzo/ozzo-validation/compare/v3.6.0...v4.3.0
Updated github.com/gobuffalo/packr      https://github.com/gobuffalo/packr/compare/v1.30.1...v2.5.1
Updated github.com/golang-migrate/migrate       https://github.com/golang-migrate/migrate/compare/v3.5.4...v4.14.1
Updated github.com/google/martian       https://github.com/google/martian/compare/v2.1.0...v3.0.0
Updated github.com/jackc/chunkreader    https://github.com/jackc/chunkreader/compare/v1.0.0...v2.0.1
Updated github.com/jackc/pgproto3       https://github.com/jackc/pgproto3/compare/v1.1.0...v2.2.0
Updated github.com/russross/blackfriday https://github.com/russross/blackfriday/compare/v1.5.2...v2.1.0
Updated github.com/urfave/cli   https://github.com/urfave/cli/compare/v1.22.4...v2.3.0
```
